### PR TITLE
Datalab 4457: Add novelty, popularity-based metrics into BBCReclist

### DIFF
--- a/reclist/datasets.py
+++ b/reclist/datasets.py
@@ -62,9 +62,9 @@ class BBCSoundsDataset(RecDataset):
         train_filepath = os.path.join(cache_dir, "train.ndjson")
 
         if not os.path.exists(train_filepath) or self.force_download:
-            download_file(BBC_SOUNDS_TRAIN_GCP_URL, train_filepath)
+            download_with_progress(BBC_SOUNDS_TRAIN_GCP_URL, train_filepath)
         if not os.path.exists(test_filepath) or self.force_download:
-            download_file(BBC_SOUNDS_TEST_GCP_URL, test_filepath)
+            download_with_progress(BBC_SOUNDS_TEST_GCP_URL, test_filepath)
 
         def _format_data(filename):
             """
@@ -134,13 +134,11 @@ class MovieLensDataset(RecDataset):
                 zip_file.extractall(temp_dir)
             with open(os.path.join(temp_dir, "dataset.json")) as f:
                 data = json.load(f)
-        print(data['catalog'])
+
         self._x_train = data["x_train"]
         self._y_train = None
         self._x_test = data["x_test"]
-        print(self._x_test[0:2])
         self._y_test = data["y_test"]
-        print(self._y_test[0:2])
         self._catalog = self._convert_catalog_keys(data["catalog"])
 
     def _convert_catalog_keys(self, catalog):

--- a/reclist/datasets.py
+++ b/reclist/datasets.py
@@ -7,7 +7,7 @@ from reclist.utils.config import *
 from itertools import groupby
 
 
-class BBCSoundsSampledDataset(RecDataset):
+class BBCSoundsDataset(RecDataset):
     """
     BBC Sounds September 2021 Dataset
 
@@ -134,11 +134,13 @@ class MovieLensDataset(RecDataset):
                 zip_file.extractall(temp_dir)
             with open(os.path.join(temp_dir, "dataset.json")) as f:
                 data = json.load(f)
-
+        print(data['catalog'])
         self._x_train = data["x_train"]
         self._y_train = None
         self._x_test = data["x_test"]
+        print(self._x_test[0:2])
         self._y_test = data["y_test"]
+        print(self._y_test[0:2])
         self._catalog = self._convert_catalog_keys(data["catalog"])
 
     def _convert_catalog_keys(self, catalog):

--- a/reclist/metrics/novelty.py
+++ b/reclist/metrics/novelty.py
@@ -1,0 +1,137 @@
+""" Collection of novelty-based metrics """
+from collections import defaultdict
+import numpy as np
+
+
+def gini_index_at_k(y_preds, candidate_list, k: int=10, debug: bool=False) -> float:
+    no_items = len(set(candidate_list))
+    all_preds = []
+    for _p in y_preds:
+        all_preds += _p[:k]
+    all_preds_flattened = np.asarray(all_preds)
+    items, counts = np.unique(all_preds_flattened, return_counts=True)
+    counts.sort()
+    num_recommended_items = counts.shape[0]
+    total_num = len(y_preds)*k
+    idx = np.arange(no_items-num_recommended_items+1, no_items+1)
+    gini_index = np.sum((2*idx-no_items-1)*counts)/total_num
+    gini_index /= no_items
+    return gini_index
+
+def gini_index_at_k_user_differential(y_preds, y_test, candidate_list, k=10,
+                                      debug=False, user_feature='age_range', **kwargs):
+    breakdown = _breakdown_preds_by_user_feature(y_test, y_preds,
+                                                 user_feature=user_feature)
+
+    return _apply_func_to_breakdown(gini_index_at_k, breakdown, candidate_list,
+                                    k=k, debug=debug)
+    return {key: gini_index_at_k(val, candidate_list, k=k, debug=debug, **kwargs)
+            for key, val in sorted(breakdown.items(), key=lambda x:x[0])}
+
+
+def shannon_entropy_at_k(y_preds, k: int=10, debug: bool=False) -> float:
+    all_preds = []
+    for _p in y_preds:
+        all_preds += _p[:k]
+    all_preds_flattened = np.asarray(all_preds)
+    items, counts = np.unique(all_preds_flattened, return_counts=True)
+    total_num = len(y_preds)*k
+    p = counts/total_num
+    return (-p*np.log(p)).sum()
+
+
+def shannon_entropy_at_k_user_differential(y_test, y_preds, k=10,
+                                           debug=False, user_feature='gender', **kwargs):
+    breakdown = _breakdown_preds_by_user_feature(y_test, y_preds,
+                                                 user_feature=user_feature)
+
+    return _apply_func_to_breakdown(shannon_entropy_at_k, breakdown,
+                                    k=k, debug=debug)
+
+
+def novelty_at_k(y_preds, x_train, k=10, debug=False):
+    all_inters = []
+    for user in x_train:
+        for interaction in user:
+            all_inters.append(interaction['resourceId'])
+    all_inters = np.asarray(all_inters)
+    items, counts = np.unique(all_inters, return_counts=True)
+    pop_lookup = {i[0]: i[1] for i in zip(items, counts)}
+    msi = []
+    n = 0
+    no_users = len(x_train)  # each entry is a user
+    for _p in y_preds:
+        self_information = 0
+        n += 1
+        for i in _p[:k]:
+            try:
+                self_information += np.sum(-np.log2(pop_lookup[i]/no_users))
+            except KeyError:
+                self_information += np.sum(-np.log2(1/no_users))
+        msi.append(self_information/k)
+    return sum(msi)/n
+
+
+def novelty_at_k_user_differential(x_train, y_test, y_preds, k=10,
+                                   debug=False, user_feature='gender', **kwargs):
+    breakdown = _breakdown_preds_by_user_feature(y_test, y_preds,
+                                                 user_feature=user_feature)
+    return _apply_func_to_breakdown(novelty_at_k, breakdown, x_train, k=k, debug=debug)
+
+
+def personalisation_at_k(y_preds, k=10, debug=False):
+    import itertools
+    import tqdm
+    _id = 0
+    item_ids = {}
+    for i in y_preds:
+        for j in i:
+            if j not in item_ids:
+                item_ids[j] = _id
+                _id += 1
+    total_similarity = 0
+
+    # iterate over each pair of users and compute similarity
+    no_users = len(y_preds)
+    print(no_users)
+    no_combinations = no_users*(no_users-1)/2
+    user_vector_cache = {}
+
+    def get_vector(cache, id, k, item_ids, y_preds):
+        try:
+            return cache[id]
+        except KeyError:
+            user_vector_ids = set([item_ids[i] for i in y_preds[id][:k]])
+            cache[id] = user_vector_ids
+            return user_vector_ids
+
+    # Make this speedy by using a.b/|a|/|b|, and caching a,b throughout
+    # a, b are len(no_items), all zeros apart from indices of the top k items, which are ==1
+    # therefore a.b = number of items in both a, b
+    # As only k recommendations, |a| == |b|, |a|^2 = k, which factorises out
+    # so compute (a & b) for all unique a,b pairs
+    # divide by k
+    # divide by number of pairs
+    # n.b. doing it the full way (numpy vectors) for 10k users took 2hrs, this takes 30s
+    for id1, id2 in tqdm.tqdm(itertools.combinations(range(no_users), 2),
+                              total=no_combinations):
+        v1 = get_vector(user_vector_cache, id1, k, item_ids, y_preds)
+        v2 = get_vector(user_vector_cache, id2, k, item_ids, y_preds)
+        total_similarity += len(v1 & v2)
+    return 1-(total_similarity/no_combinations/k)
+
+
+def _breakdown_preds_by_user_feature(y_test, y_preds, user_feature='gender'):
+    breakdown = defaultdict(list)
+    for _t, _p in zip(y_test, y_preds):
+        target_user_feature = _t[0][user_feature]
+        if not target_user_feature:
+            target_user_feature = 'unknown'
+        breakdown[target_user_feature].append(_p)
+    return breakdown
+
+
+def _apply_func_to_breakdown(func, breakdown, *args, **kwargs):
+    return {key: func(val, *args, **kwargs)
+            for key, val in sorted(breakdown.items(),
+                                   key=lambda x:x[0])}

--- a/reclist/metrics/novelty.py
+++ b/reclist/metrics/novelty.py
@@ -1,7 +1,11 @@
 """ Collection of novelty-based metrics """
 from collections import defaultdict
+import os
+
 import matplotlib.pyplot as plt
 import numpy as np
+
+from reclist.current import current
 
 
 def gini_index_at_k(y_preds, candidate_list, k: int=10, debug: bool=False) -> float:
@@ -153,5 +157,5 @@ def plot_results_breakdown(results, fname, metric, xmin=None, xmax=None):
     if xmax is not None:
         plt.xlim(right=xmax)
     plt.grid(alpha=0.5, color='gray', ls=':')
-    plt.savefig(fname)
+    plt.savefig(os.path.join(current.report_path, 'plots', fname))
     plt.close()

--- a/reclist/metrics/standard_metrics.py
+++ b/reclist/metrics/standard_metrics.py
@@ -136,6 +136,53 @@ def recall_at_k(y_preds, y_test, k=3):
     return np.average(recall_ls)
 
 
+def ndcg_at_k(y_preds, y_test, k=3):
+    import sklearn.metrics
+    results = list(reversed(list(range(1, k+1))))
+    user_ndcgs = []
+    for _p, _y in zip(y_preds, y_test):
+        relevance = []
+        for j in _p[:k]:
+            if j in _y:
+                relevance.append(1)
+            else:
+                relevance.append(0)
+
+        # 0 pad relevance to k if there are fewer than k predictions
+        if len(relevance) < k:
+            relevance += [0]*(k-len(relevance))
+
+        user_ndcgs.append(sklearn.metrics.ndcg_score([relevance], [results]))
+    return np.average(np.asarray(user_ndcgs))
+
+def ndcg_at_k_user_differential(y_preds, y_test, y_test_full, k=3,
+                                user_feature='gender'):
+    pred_breakdown, test_breakdown = _breakdown_preds_by_user_feature(y_test_full, y_preds, y_test,
+                                                                      user_feature=user_feature)
+    return _apply_func_to_breakdown(ndcg_at_k, pred_breakdown, test_breakdown, k=k)
+
+
+def _breakdown_preds_by_user_feature(y_test, y_preds, y_test_ids, user_feature='gender'):
+    from collections import defaultdict
+    pred_breakdown = defaultdict(list)
+    test_breakdown = defaultdict(list)
+    for _t, _p, _t_ids in zip(y_test, y_preds, y_test_ids):
+        target_user_feature = _t[0][user_feature]
+        if not target_user_feature:
+            target_user_feature = 'unknown'
+        pred_breakdown[target_user_feature].append(_p)
+        test_breakdown[target_user_feature].append(_t_ids)
+    return pred_breakdown, test_breakdown
+
+
+def _apply_func_to_breakdown(func, pred_breakdown, test_breakdown, *args, **kwargs):
+    retval = {}
+    for key in sorted(pred_breakdown.keys()):
+        retval[key] = func(pred_breakdown[key], test_breakdown[key], *args, **kwargs)
+    return retval
+
+
+
 def rec_items_distribution_at_k(y_preds, k=3, bin_width=100, debug=True):
     def _calculate_hist(frequencies, bins):
         """ Works out the counts of items in each bucket """

--- a/reclist/reclist.py
+++ b/reclist/reclist.py
@@ -448,7 +448,8 @@ class BBCSoundsRecList(RecList):
         from reclist.metrics.novelty import shannon_entropy_at_k_user_differential
         return shannon_entropy_at_k_user_differential(self._y_test,
                                                       self.resourceid_only(self._y_preds),
-                                                      k=10, user_feature='gender')
+                                                      k=10, user_feature='gender',
+                                                      debug=True)
 
     @rec_test(test_type='GiniIndex@10')
     def gini_index_at_k(self):
@@ -477,7 +478,8 @@ class BBCSoundsRecList(RecList):
         return gini_index_at_k_user_differential(self.resourceid_only(self._y_preds),
                                                  self._y_test,
                                                  self.product_data,
-                                                 k=10)
+                                                 k=10,
+                                                 debug=True)
 
     @rec_test(test_type='Coverage@10')
     def coverage_at_k(self):
@@ -515,7 +517,8 @@ class BBCSoundsRecList(RecList):
         return novelty_at_k_user_differential(self._x_train,
                                               self._y_test,
                                               self.resourceid_only(self._y_preds),
-                                              k=10, user_feature='age_range')
+                                              k=10, user_feature='age_range',
+        debug=True)
 
 
     @rec_test(test_type='NDCG@10')

--- a/reclist/reclist.py
+++ b/reclist/reclist.py
@@ -431,16 +431,121 @@ class BBCSoundsRecList(RecList):
         return popularity_bias_at_k(self.resourceid_only(self._y_preds),
                                     self.resourceid_only(self._x_train),
                                     k=10)
+    @rec_test(test_type='Entropy@10')
+    def shannon_entropy_at_k(self):
+        """ Shannon Entropy is a measure of the information content/'randomness' of the prediction set.
 
-    @rec_test(test_type='freq_of_recommended_items_at_k')
-    def rec_items_distribution_at_k(self):
+        For more ‘random’ data, the Shannon entropy value is higher. For more deterministic signals, it is lower."""
+        from reclist.metrics.novelty import shannon_entropy_at_k
+        return shannon_entropy_at_k(self.resourceid_only(self._y_preds),
+                                    k=10)
+
+    @rec_test(test_type='Entropy_distribution_by_gender@10')
+    def shannon_entropy_at_k_gender(self):
+        """ Shannon Entropy is a measure of the information content/'randomness' of the prediction set.
+
+        For more ‘random’ data, the Shannon entropy value is higher. For more deterministic signals, it is lower."""
+        from reclist.metrics.novelty import shannon_entropy_at_k_user_differential
+        return shannon_entropy_at_k_user_differential(self._y_test,
+                                                      self.resourceid_only(self._y_preds),
+                                                      k=10, user_feature='gender')
+
+    @rec_test(test_type='GiniIndex@10')
+    def gini_index_at_k(self):
+        """ The Gini Index is a measure of across k recommendations for n users of
+        how equally recommendations are distributed across all items.
+          - High values G~1 mean that there is a large inequality across
+            items in how often they are recommended
+          - G~0 means that all items are recommended roughly the same
+            amount across the set of users
+        This is a measure of exposure bias resulting from the recommender"""
+        from reclist.metrics.novelty import gini_index_at_k
+        return gini_index_at_k(self.resourceid_only(self._y_preds),
+                               self.product_data,
+                               k=10)
+
+    @rec_test(test_type='GiniIndex_distribution_by_age_range@10')
+    def gini_index_at_k_age_range(self):
+        """ The Gini Index is a measure of across k recommendations for n users of
+        how equally recommendations are distributed across all items.
+          - High values G~1 mean that there is a large inequality across
+            items in how often they are recommended
+          - G~0 means that all items are recommended roughly the same
+            amount across the set of users
+        This is a measure of exposure bias resulting from the recommender"""
+        from reclist.metrics.novelty import gini_index_at_k_user_differential
+        return gini_index_at_k_user_differential(self.resourceid_only(self._y_preds),
+                                                 self._y_test,
+                                                 self.product_data,
+                                                 k=10)
+
+    @rec_test(test_type='Coverage@10')
+    def coverage_at_k(self):
         """
-        Computes the frequency of occurrence across recommended items
+        Coverage is the proportion of all possible candidate items which the RS
+        recommends based on a set of sessions
         """
-        from reclist.metrics.standard_metrics import rec_items_distribution_at_k
-        return rec_items_distribution_at_k(
-            self.resourceid_only(self._y_preds),
-            k=10,
-            bin_width=100,
-            debug=True
-        )
+        from reclist.metrics.standard_metrics import coverage_at_k
+        return coverage_at_k(self.resourceid_only(self._y_preds),
+                             {k: None for k in self.product_data},
+                             k=10)
+
+    @rec_test(test_type='Novelty@10')
+    def novelty_at_k(self):
+        """
+        Novelty is the propensity of a recommender to recommend itms that a user has little or no knowledge about.
+        Here we use a variation on eq 9. of Silveira et. al. [2017], where popularity is normalised by the number
+        of users in the training set. Item popularity is used a proxy for user knowledge. A higher novelty recommender
+        recommends less popular items more frequently
+        """
+        from reclist.metrics.novelty import novelty_at_k
+        return novelty_at_k(self.resourceid_only(self._y_preds),
+                            self._x_train,
+                            k=10)
+
+    @rec_test(test_type='Novelty@10')
+    def novelty_at_k_age_range(self):
+        """
+        Novelty is the propensity of a recommender to recommend itms that a user has little or no knowledge about.
+        Here we use a variation on eq 9. of Silveira et. al. [2017], where popularity is normalised by the number
+        of users in the training set. Item popularity is used a proxy for user knowledge. A higher novelty recommender
+        recommends less popular items more frequently
+        """
+        from reclist.metrics.novelty import novelty_at_k_user_differential
+        return novelty_at_k_user_differential(self._x_train,
+                                              self._y_test,
+                                              self.resourceid_only(self._y_preds),
+                                              k=10, user_feature='age_range')
+
+
+    @rec_test(test_type='NDCG@10')
+    def ndcg_at_k(self):
+        """
+        Normalised Discounted Cumulative Gain @ 10
+        """
+        from reclist.metrics.standard_metrics import ndcg_at_k
+        return ndcg_at_k(self.resourceid_only(self._y_preds),
+                         self.resourceid_only(self._y_test),
+                         k=10)
+
+    @rec_test(test_type='NDCG@10')
+    def ndcg_at_k_age_range(self):
+        """
+        Normalised Discounted Cumulative Gain @ 10
+        """
+        from reclist.metrics.standard_metrics import ndcg_at_k_user_differential
+        return ndcg_at_k_user_differential(self.resourceid_only(self._y_preds),
+                                           self.resourceid_only(self._y_test),
+                                           self._y_test,
+                                           k=10, user_feature='age_range')
+
+    @rec_test(test_type='Personalisation@10')
+    def personalisation_at_k(self):
+        """
+        Aggregated difference measure between user recommendations (unordered).
+        Pers@k=1 -> Each recommendation list shares no items with any others (fully disjoint)
+        Pers@k=0 -> All recommendation lists are the same for every user
+        """
+        from reclist.metrics.novelty import personalisation_at_k
+        return personalisation_at_k(self.resourceid_only(self._y_preds),
+                                    k=10)

--- a/reclist/recommenders/prod2vec.py
+++ b/reclist/recommenders/prod2vec.py
@@ -203,3 +203,58 @@ class BBCSoundsP2VRecModel(RecModel):
             return list(self.model.get_vector(movie))
         except Exception as e:
             return []
+
+
+class BBCSoundsP2VRecModel(RecModel):
+    """
+    Prod2Vec implementation for MovieLens 25M dataset
+    """
+    model_name = "prod2vec"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def train(self, resource_ids, iterations=15):
+        # Get the resource ID and label for each resource ID for each unique user
+        x_train = [[(x["resourceId"], x["label"]) for x in y] for y in resource_ids]
+        self._model = train_embeddings(x_train, iterations=iterations)
+
+    def predict(self, prediction_input, *args, **kwargs):
+        """
+        Predicts the top 10 similar resource IDs recommended for each user according
+        to the resource IDs that they've watched
+
+        :param prediction_input: a list of lists containing a dictionary for
+                                 each resource ID watched by that user
+        :return:
+        """
+        all_predictions = []
+        for movies in prediction_input:
+            predictions = []
+            emb_vecs = []
+            for movie in movies:
+                emb_vec = self.get_vector(movie)
+                if emb_vec:
+                    emb_vecs.append(emb_vec)
+            if emb_vecs:
+                # Calculate the average of all the latent vectors representing
+                # the movies watched by the user as is done in https://arxiv.org/abs/2007.14906
+                avg_emb_vec = np.mean(emb_vecs, axis=0)
+                nn_products = self.model.similar_by_vector(avg_emb_vec, topn=10)
+                for elem in nn_products:
+                    predictions.append({"resourceId": elem[0][0], "label": elem[0][1]})
+            all_predictions.append(predictions)
+        return all_predictions
+
+    def get_vector(self, x):
+        """
+        Returns the latent vector that corresponds to the movie ID and the rating
+
+        :param x:
+        :return:
+        """
+        movie = (x["resourceId"], x["label"])
+        try:
+            return list(self.model.get_vector(movie))
+        except Exception as e:
+            return []


### PR DESCRIPTION
This PR adds methods to load candidate items for a BBC Sounds dataset from GCP.

It also adds tests/implemenations of the [additional metrics](https://paper.dropbox.com/doc/Metrics-descriptions-p7KpaxJMG0vsnl3eVhYao): 
- Novelty, 
- Gini index, 
- Shannon Entropy,
- Personalisation,
- NDCG